### PR TITLE
Use the latest version of the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Generated
+
+Elm.docset
+Elm.tgz
+cache.json
+
+# Python
+
+__pycache__

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ To generate, execute `generate.py`.
 Requirements: `pybars3`, `markdown` and `requests`.
 
 You can download the latest version of the docset from User Contributed Section in Dash's Preferences pane. 
+
+To package, execute  `pack.sh`.

--- a/generate.py
+++ b/generate.py
@@ -324,7 +324,11 @@ def generate_all():
         idx = pkgs.index(pkg)+1
         pkg_name = pkg["name"]
         pkg_file = docname(pkg_name)
-        pkg_version = pkg["versions"][0]
+        try:
+            pkg_version = pkg["versions"][-1]
+        except IndexError:
+            print ("No version found, skipping package: %s"%pkg_name)
+            continue
         print ("Generating package: "+pkg_name+" [% 3d / %03d]..."%(idx, no_pkgs), end="") 
  
         json = fetch( pkgsURL+"/".join(["packages", pkg_name, pkg_version, "docs"])+".json")


### PR DESCRIPTION
Thank you for writing `elm-docset`. 🙏🏻

A package I'm using was out-of-date, so I thought I'd submit a PR to Dash to update the user-contrib version there.

When I ran `elm-docset`, I noticed it uses the first version, which isn't the latest. For example:

```json
{
  "name": "hecrj/composable-form",
  "summary": "Build type-safe composable forms in Elm",
  "license": "BSD-3-Clause",
  "versions": [
    "4.0.1",
    "5.0.0",
    "6.0.1"
  ]
}
```

With `pkg["versions"][0]` it would get `4.0.1`, instead of `6.0.1`.

This patch gets the latest. The ordering of versions from a cursory look (in `cache.json`) appears to be consistently ordered.

I ran this locally, packaged up the docset, and added it do Dash and it's working fine ([screenshot](https://i0pqzjlkwohkzup1knom.s3-eu-central-1.amazonaws.com/public/dash-composable-form-6.0.1.png)).

I also added a bascic `.gitignore` file, and a small update to the README, but feel free to drop them.