### PR TITLE
Fix copypaste error, add package name to module in index

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -256,14 +256,14 @@ class Module(object):
 
                 elif item in self.types:
                     
-                    da = self.insert_in_db(self.types[item].qualified_name, self.values[item].name, "Union")
+                    da = self.insert_in_db(self.types[item].qualified_name, self.types[item].name, "Union")
                     ret.append(da) #DashAnchor
                     ret.append(self.types[item].markdown)
                     
 
                 elif item in self.aliases:
                     
-                    da = self.insert_in_db(self.aliases[item].qualified_name, self.values[item].name, "Type")
+                    da = self.insert_in_db(self.aliases[item].qualified_name, self.aliases[item].name, "Type")
                     ret.append(da) #DashAnchor
                     ret.append(self.aliases[item].markdown)
             except: 
@@ -346,7 +346,7 @@ def generate_all():
                 html = toHtml(module.markdown).replace('<code>', '<code class="elm">') # fix syntax detection
                 data = { "pkg_link": (pkg_name, pkg_file), "module_name":module.name, "markdown":html}
                 fo.write(moduleTemplate(data))
-            cur.execute('INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES (?,?,?)', (module.name, 'Module', module_file))
+            cur.execute('INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES (?,?,?)', (module.name + ' (' + pkg_name + ')', 'Module', module_file))
 
         with open(opj(docpath, pkg_file), "wb") as fo:
             data = { "pkg_name": pkg_name, "modules":links, "version":pkg_version}


### PR DESCRIPTION
Sorry, I've found an error in my previous PR. Essentially went to look for an item in `values` when in a `types` branch etc.

That had the consequence of not adding any type aliases and union types to the docset. Oops!

----

Another change in this PR is adding the package name to the module in the SQLite index. So we can distinguish between modules of the same name:

```
Cmd.Extra (GlobalWebIndex/cmd-extra)
Cmd.Extra (Janiczek/cmd-extra)
```

This might or might not be a good idea - I'm not sure yet. Helps me for now. I'll let you be the judge :) Can delete it if you won't want it.