### PR TITLE
Add Dockerfile with python environment and build requirements built in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cache.json
 # Python
 
 __pycache__
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2.7-slim
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,21 @@ Requirements: `pybars3`, `markdown` and `requests`.
 You can download the latest version of the docset from User Contributed Section in Dash's Preferences pane. 
 
 To package, execute  `pack.sh`.
+
+## Using Docker
+You can build docker image with python and requirements installed
+```
+docker build -t elm-docset .
+```
+
+and then run the script
+
+```
+docker run -it --rm --name elm-docset -v "$PWD":/usr/src/app elm-docset python generate.py
+```
+
+You can also run packaging script within docker if you would like
+
+```
+docker run -it --rm --name elm-docset -v "$PWD":/usr/src/app elm-docset pack.sh 
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Markdown == 2.6.6
 pybars3 == 0.9.1
 requests == 2.20.0
-pybars == 0.0.4


### PR DESCRIPTION
This PR adds Dockerfile so it is easier to build the docsets without compromising your own environment just for the sake of build docsets