### PR TITLE
Ensure Anchor URLs used by Sidebar are well-formed

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -4,6 +4,8 @@
 from __future__ import print_function
 import shutil, os, re 
 import sqlite3
+import urllib.parse
+import functools
 
 import json
 from cache import fetch
@@ -227,7 +229,14 @@ class Module(object):
         
         if not DEBUG:
             cur.execute('INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES (?,?,?)', (qualified_name, kind, file_name+"#"+sname))
-        return '<a name="//apple_ref/cpp/%s/%s" class="dashAnchor"></a>'%(kind, sname)
+
+        # Return a HTML Anchor to be used for Table-of-Contents (the sidebar) support.
+        # REF: https://kapeli.com/docsets#tableofcontents
+        percent_encode_path_component = functools.partial(urllib.parse.quote, safe='')
+        return '<a name="//apple_ref/cpp/%s/%s" class="dashAnchor"></a>' % (
+            percent_encode_path_component(kind),
+            percent_encode_path_component(sname),
+        )
 
     def expand_docs(self, content):
         ret = []


### PR DESCRIPTION
Operators containing the forward-slash character are not playing well with the Sidebar, e.g. in `elm/core Basics`:

![image](https://user-images.githubusercontent.com/172663/76968274-8a658380-6920-11ea-843b-8cc419dfff14.png)

This is because the HTML Anchor being generated is e.g. 

```html
<a name="//apple_ref/cpp/Operator/(/)" class="dashAnchor"></a>
```

Notice the part being appended onto the static prefix (`//apple_ref/cpp/`) has a forward-slash in it that's ambiguous vs. actual path separators.

---

With this PR, it will be the following:

```html
<a name="//apple_ref/cpp/Operator/%28%2F%29" class="dashAnchor"></a>
```

I generated the DocSet locally (requiring the other PR I just submitted because of unrelated server JSON changes) and verified it works.








